### PR TITLE
Updated workflow triggers in build_connectors.yml

### DIFF
--- a/.github/workflows/build_connectors.yml
+++ b/.github/workflows/build_connectors.yml
@@ -1,19 +1,16 @@
 name: Dynamically Build Docker Images for Changed Connectors
 
 on:
-  push:
-    branches:
-      - "master"
-    paths:
-      - "airbyte-integrations/connectors/**"
-    tags:
-      - "v*"
   pull_request:
     branches: [master]
+    types:
+      - closed
     paths:
       - "airbyte-integrations/connectors/**"
+
 jobs:
   prepare-matrix:
+    if: github.event.pull_request.merge == true
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.find-changes.outputs.matrix }}


### PR DESCRIPTION
The GitHub Actions workflow for building Docker images has been updated. The trigger conditions have been modified to only run the job when a pull request is closed and merged into the master branch, instead of on every push to master or tag creation. This change optimizes our CI/CD pipeline by reducing unnecessary builds.
