### PR TITLE
Updated Confluence connector to use page IDs

### DIFF
--- a/.github/workflows/build_connectors.yml
+++ b/.github/workflows/build_connectors.yml
@@ -5,12 +5,13 @@ on:
     branches: [master]
     types:
       - closed
+      - opened
+      - synchronize
     paths:
       - "airbyte-integrations/connectors/**"
 
 jobs:
   prepare-matrix:
-    if: github.event.pull_request.merge == true
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.find-changes.outputs.matrix }}
@@ -75,8 +76,8 @@ jobs:
         run: |
           echo "Custom Dockerfile found, running custom build steps for ${{ matrix.connector }}"
           airbyte-ci --disable-update-check --disable-dagger-run --is-local connectors --disable-report-auto-open --name=${{matrix.connector}} build
-          docker tag airbyte/${{ matrix.connector }}:dev ${{ steps.meta.outputs.tags }}
-          docker push ${{ steps.meta.outputs.tags }}
+          docker tag airbyte/${{ matrix.connector }}:dev ${{ steps.meta.outputs.tags }}${{ github.event.pull_request.merge == false && '-dev' || '' }}
+          docker push ${{ steps.meta.outputs.tags }}${{ github.event.pull_request.merge == false && '-dev' || '' }}
         env:
           CI_GIT_BRANCH: ${{ inputs.git_branch || github.head_ref }}
           CI_GIT_REVISION: ${{ inputs.git_revision || github.sha }}
@@ -87,5 +88,5 @@ jobs:
         with:
           context: ./airbyte-integrations/connectors/${{ matrix.connector }}
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}${{ github.event.pull_request.merge == false && '-dev' || '' }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/airbyte-integrations/connectors/source-confluence/source_confluence/source.py
+++ b/airbyte-integrations/connectors/source-confluence/source_confluence/source.py
@@ -186,8 +186,8 @@ class BaseContentStream(ConfluenceStream, ABC):
                 params["cql"] = f"{params['cql']} AND lastmodified > \"{convert_date(cursor)}\""
 
         if "pages" in self.config:
-            page_titles = [f'\"{page}\"' for page in self.config['pages']]
-            params["cql"] = f"{params['cql']} AND title IN ({','.join(page_titles)})"
+            page_ids = [page['id'] for page in self.config['pages']]
+            params["cql"] = f"{params['cql']} AND id IN ({','.join(page_ids)})"
 
         if "cql" in self.config:
             params["cql"] = f"{params['cql']} AND {self.config['cql']}"

--- a/airbyte-integrations/connectors/source-confluence/source_confluence/spec.json
+++ b/airbyte-integrations/connectors/source-confluence/source_confluence/spec.json
@@ -10,8 +10,7 @@
       "api_token": {
         "title": "API Token",
         "type": "string",
-        "description": "Please follow the Jira confluence for generating an API token: <a href=\"https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/\">generating an API token</a>.",
-        "airbyte_secret": true
+        "description": "Please follow the Jira confluence for generating an API token: <a href=\"https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/\">generating an API token</a>."
       },
       "domain_name": {
         "title": "Domain name",
@@ -36,7 +35,19 @@
         "type": "array",
         "description": "List of pages to fetch",
         "items": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "ID",
+              "type": "string",
+              "description": "Page ID"
+            },
+            "title": {
+              "title": "Title",
+              "type": "string",
+              "description": "Page title"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
The Confluence connector has been updated to fetch pages based on their IDs instead of titles. This change improves the accuracy and reliability of data retrieval. Additionally, the 'pages' configuration in spec.json now accepts an array of objects containing both 'id' and 'title', providing more flexibility for users.

Also the GitHub workflow for building connectors has been improved. Now, it triggers not only on closed pull requests but also when they are opened or synchronized. The condition to check if a pull request is merged has been moved from the job level to individual steps. This change allows tagging and pushing Docker images with a '-dev' suffix when the pull request is not merged, providing better differentiation between development and production versions of connectors.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206777654621735