### PR TITLE
Updated content stream fields

### DIFF
--- a/airbyte-integrations/connectors/source-confluence/source_confluence/source.py
+++ b/airbyte-integrations/connectors/source-confluence/source_confluence/source.py
@@ -194,6 +194,7 @@ class BaseContentStream(ConfluenceStream, ABC):
         "body",
         "body.storage",
         "body.view",
+        "body.styled_view",
     ]
     limit = 25
     content_type = None


### PR DESCRIPTION
Added "body.styled_view" to the list of fields in BaseContentStream. This will allow styled views to be included in the data fetched from Confluence.
