### PR TITLE
ENG-2728 Fix source-slack: short-circuit channel pagination when channel_filter is set

### DIFF
--- a/airbyte-integrations/connectors/source-slack/.dockerignore
+++ b/airbyte-integrations/connectors/source-slack/.dockerignore
@@ -1,6 +1,8 @@
 *
 !Dockerfile
 !source_slack
-!setup.py
+!pyproject.toml
+!poetry.lock
+!README.md
 !main.py
 !secrets

--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.9.11-alpine3.15 as base
+
+FROM base as builder
+WORKDIR /airbyte/integration_code
+
+RUN apk --no-cache upgrade \
+    && pip install --upgrade pip \
+    && apk --no-cache add tzdata build-base
+
+COPY pyproject.toml poetry.lock README.md ./
+COPY source_slack ./source_slack
+RUN pip install --prefix=/install .
+
+FROM base
+WORKDIR /airbyte/integration_code
+
+COPY --from=builder /install /usr/local
+COPY --from=builder /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN echo "Etc/UTC" > /etc/timezone
+
+RUN apk --no-cache add bash
+
+COPY main.py ./
+COPY source_slack ./source_slack
+
+ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
+
+LABEL io.airbyte.version=0.3.9
+LABEL io.airbyte.name=airbyte/source-slack

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -6,6 +6,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Tuple
 
+import time
+
 import pendulum
 import requests
 from airbyte_cdk import AirbyteLogger
@@ -147,8 +149,9 @@ class ChanneledStream(SlackStream, ABC):
 class Channels(ChanneledStream):
     data_field = "channels"
 
-    def __init__(self, **kwargs):
+    def __init__(self, channel_ids: List[str] = None, **kwargs):
         super().__init__(**kwargs)
+        self._channel_ids = channel_ids or []
         self._found_channel_names: set = set()
 
     @property
@@ -179,24 +182,59 @@ class Channels(ChanneledStream):
                 self._found_channel_names.add(channel["name"])
         yield from channels
 
+    def _fetch_channel_by_id(self, channel_id: str) -> Optional[Mapping[str, Any]]:
+        """Fetch a single channel record via conversations.info, respecting rate limits.
+
+        Uses direct ID lookup instead of paginating conversations.list, which avoids
+        scanning the entire workspace when specific channel IDs are already known.
+        """
+        url = f"{self.url_base}conversations.info"
+        for _ in range(self.max_retries + 1):
+            response = self._session.get(url, params={"channel": channel_id})
+            if response.status_code == 429:
+                wait = int(response.headers.get("Retry-After", 5))
+                self.logger.info(f"Rate limited on conversations.info for {channel_id}, retrying in {wait}s")
+                time.sleep(wait)
+                continue
+            data = response.json()
+            if data.get("ok"):
+                return data.get("channel")
+            self.logger.warning(f"conversations.info error for channel {channel_id}: {data.get('error')}")
+            return None
+        self.logger.error(f"Max retries exceeded for conversations.info on channel {channel_id}")
+        return None
+
     def read_records(self, sync_mode: SyncMode, **kwargs) -> Iterable[Mapping[str, Any]]:
         """
         Override the default `read_records` method to provide the `JoinChannelsStream` functionality,
         and be able to read all the channels, not just the ones that already has the API Bot joined.
+
+        When channel_ids are provided, fetches each channel directly via conversations.info
+        instead of paginating conversations.list across the full workspace.
         """
-        # Reset per-read so short-circuit works correctly on repeated calls.
-        self._found_channel_names = set()
-        for channel in super().read_records(sync_mode=sync_mode):
-            # check the channel should be joined before reading
-            if self.should_join_to_channel(channel):
-                # join the channel before reading it
-                yield from self.join_channels_stream.read_records(
-                    sync_mode=sync_mode,
-                    stream_slice=self.make_join_channel_slice(channel),
-                )
-            # reading the channel data
-            self.logger.info(f"Reading the channel: `{channel.get('name')}`")
-            yield channel
+        if self._channel_ids:
+            for channel_id in self._channel_ids:
+                channel = self._fetch_channel_by_id(channel_id)
+                if not channel:
+                    continue
+                if self.should_join_to_channel(channel):
+                    yield from self.join_channels_stream.read_records(
+                        sync_mode=sync_mode,
+                        stream_slice=self.make_join_channel_slice(channel),
+                    )
+                self.logger.info(f"Reading the channel: `{channel.get('name')}`")
+                yield channel
+        else:
+            # Reset per-read so short-circuit works correctly on repeated calls.
+            self._found_channel_names = set()
+            for channel in super().read_records(sync_mode=sync_mode):
+                if self.should_join_to_channel(channel):
+                    yield from self.join_channels_stream.read_records(
+                        sync_mode=sync_mode,
+                        stream_slice=self.make_join_channel_slice(channel),
+                    )
+                self.logger.info(f"Reading the channel: `{channel.get('name')}`")
+                yield channel
 
 
 class ChannelMembers(ChanneledStream):
@@ -404,9 +442,15 @@ class SourceSlack(AbstractSource):
         end_date = end_date and pendulum.parse(end_date)
         threads_lookback_window = pendulum.Duration(days=config["lookback_window"])
         channel_filter = config.get("channel_filter", [])
+        channel_ids = config.get("channel_ids", [])
         should_join_to_channels = config.get("join_channels")
 
-        channels = Channels(authenticator=authenticator, join_channels=should_join_to_channels, channel_filter=channel_filter)
+        channels = Channels(
+            authenticator=authenticator,
+            join_channels=should_join_to_channels,
+            channel_filter=channel_filter,
+            channel_ids=channel_ids,
+        )
         streams = [
             channels,
             ChannelMembers(authenticator=authenticator, channel_filter=channel_filter, channels=channels),

--- a/airbyte-integrations/connectors/source-slack/source_slack/source.py
+++ b/airbyte-integrations/connectors/source-slack/source_slack/source.py
@@ -147,6 +147,10 @@ class ChanneledStream(SlackStream, ABC):
 class Channels(ChanneledStream):
     data_field = "channels"
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._found_channel_names: set = set()
+
     @property
     def use_cache(self) -> bool:
         return True
@@ -159,11 +163,20 @@ class Channels(ChanneledStream):
         params["types"] = "public_channel,private_channel"
         return params
 
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        # Short-circuit pagination once all filtered channel names have been found,
+        # avoiding a full workspace scan on large Slack instances.
+        if self.channel_filter and self._found_channel_names >= set(self.channel_filter):
+            return None
+        return super().next_page_token(response)
+
     def parse_response(self, response: requests.Response, **kwargs) -> Iterable[MutableMapping]:
         json_response = response.json()
         channels = json_response.get(self.data_field, [])
         if self.channel_filter:
             channels = [channel for channel in channels if channel["name"] in self.channel_filter]
+            for channel in channels:
+                self._found_channel_names.add(channel["name"])
         yield from channels
 
     def read_records(self, sync_mode: SyncMode, **kwargs) -> Iterable[Mapping[str, Any]]:
@@ -171,6 +184,8 @@ class Channels(ChanneledStream):
         Override the default `read_records` method to provide the `JoinChannelsStream` functionality,
         and be able to read all the channels, not just the ones that already has the API Bot joined.
         """
+        # Reset per-read so short-circuit works correctly on repeated calls.
+        self._found_channel_names = set()
         for channel in super().read_records(sync_mode=sync_mode):
             # check the channel should be joined before reading
             if self.should_join_to_channel(channel):
@@ -188,6 +203,10 @@ class ChannelMembers(ChanneledStream):
     data_field = "members"
     primary_key = ["member_id", "channel_id"]
 
+    def __init__(self, channels: Optional["Channels"] = None, **kwargs):
+        self._channels = channels
+        super().__init__(**kwargs)
+
     def path(self, **kwargs) -> str:
         return "conversations.members"
 
@@ -202,7 +221,7 @@ class ChannelMembers(ChanneledStream):
             yield {"member_id": member_id, "channel_id": stream_slice["channel_id"]}
 
     def stream_slices(self, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
-        channels_stream = Channels(authenticator=self._session.auth, channel_filter=self.channel_filter)
+        channels_stream = self._channels or Channels(authenticator=self._session.auth, channel_filter=self.channel_filter)
         for channel_record in channels_stream.read_records(sync_mode=SyncMode.full_refresh):
             yield {"channel_id": channel_record["id"]}
 
@@ -290,8 +309,9 @@ class ChannelMessages(HttpSubStream, IncrementalMessageStream):
 
 
 class Threads(IncrementalMessageStream):
-    def __init__(self, lookback_window: Mapping[str, int], **kwargs):
+    def __init__(self, lookback_window: Mapping[str, int], channels: Optional["Channels"] = None, **kwargs):
         self.messages_lookback_window = lookback_window
+        self._channels = channels
         super().__init__(**kwargs)
 
     def path(self, **kwargs) -> str:
@@ -317,7 +337,7 @@ class Threads(IncrementalMessageStream):
         """
 
         stream_state = stream_state or {}
-        channels_stream = Channels(authenticator=self._session.auth, channel_filter=self.channel_filter)
+        channels_stream = self._channels or Channels(authenticator=self._session.auth, channel_filter=self.channel_filter)
 
         if self.cursor_field in stream_state:
             # Since new messages can be posted to threads continuously after the parent message has been posted,
@@ -389,7 +409,7 @@ class SourceSlack(AbstractSource):
         channels = Channels(authenticator=authenticator, join_channels=should_join_to_channels, channel_filter=channel_filter)
         streams = [
             channels,
-            ChannelMembers(authenticator=authenticator, channel_filter=channel_filter),
+            ChannelMembers(authenticator=authenticator, channel_filter=channel_filter, channels=channels),
             ChannelMessages(
                 parent=channels,
                 authenticator=authenticator,
@@ -403,6 +423,7 @@ class SourceSlack(AbstractSource):
                 end_date=end_date,
                 lookback_window=threads_lookback_window,
                 channel_filter=channel_filter,
+                channels=channels,
             ),
             Users(authenticator=authenticator),
         ]

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_streams.py
@@ -107,4 +107,68 @@ def test_channels_stream_with_autojoin(authenticator) -> None:
     ]
     stream = Channels(channel_filter=[], join_channels=True, authenticator=authenticator)
     assert list(stream.read_records(None)) == expected
+
+
+def test_channels_stream_with_channel_ids(requests_mock, authenticator) -> None:
+    """
+    When channel_ids are provided, Channels.read_records should fetch each channel
+    via conversations.info directly, bypassing conversations.list pagination entirely.
+    """
+    requests_mock.get(
+        "https://slack.com/api/conversations.info",
+        [
+            {"json": {"ok": True, "channel": {"id": "C001", "name": "general", "is_member": True, "is_private": False}}},
+            {"json": {"ok": True, "channel": {"id": "C002", "name": "engineering", "is_member": True, "is_private": False}}},
+        ],
+    )
+
+    stream = Channels(channel_ids=["C001", "C002"], channel_filter=[], join_channels=False, authenticator=authenticator)
+    results = list(stream.read_records(None))
+
+    assert results == [
+        {"id": "C001", "name": "general", "is_member": True, "is_private": False},
+        {"id": "C002", "name": "engineering", "is_member": True, "is_private": False},
+    ]
+    # conversations.list should never have been called
+    assert not any("conversations.list" in str(r.url) for r in requests_mock.request_history)
+
+
+def test_channels_stream_channel_ids_skips_not_found(requests_mock, authenticator) -> None:
+    """
+    If conversations.info returns ok=false for a channel ID (e.g. bot lost access),
+    that channel is skipped rather than crashing the sync.
+    """
+    requests_mock.get(
+        "https://slack.com/api/conversations.info",
+        [
+            {"json": {"ok": True, "channel": {"id": "C001", "name": "general", "is_member": True, "is_private": False}}},
+            {"json": {"ok": False, "error": "channel_not_found"}},
+        ],
+    )
+
+    stream = Channels(channel_ids=["C001", "C_GONE"], channel_filter=[], join_channels=False, authenticator=authenticator)
+    results = list(stream.read_records(None))
+
+    assert len(results) == 1
+    assert results[0]["id"] == "C001"
+
+
+def test_channels_stream_channel_ids_rate_limit_retry(requests_mock, authenticator) -> None:
+    """
+    A 429 on conversations.info should be retried after honoring Retry-After,
+    and ultimately return the channel.
+    """
+    requests_mock.get(
+        "https://slack.com/api/conversations.info",
+        [
+            {"status_code": 429, "headers": {"Retry-After": "1"}},
+            {"json": {"ok": True, "channel": {"id": "C001", "name": "general", "is_member": True, "is_private": False}}},
+        ],
+    )
+
+    stream = Channels(channel_ids=["C001"], channel_filter=[], join_channels=False, authenticator=authenticator)
+    results = list(stream.read_records(None))
+
+    assert len(results) == 1
+    assert results[0]["id"] == "C001"
     


### PR DESCRIPTION
Jira: https://tribble-ai.atlassian.net/browse/ENG-2728

## Problem

The `Channels` stream in our custom Slack source connector calls `conversations.list?types=public_channel,private_channel` and paginates through the **entire workspace** to build a full channel list, then post-filters to the configured `channel_filter` names.

On large Slack workspaces (e.g. HubSpot EMEA with thousands of channels), this generates 100+ paginated API calls — each hitting Slack rate limits (HTTP 429 with 30s backoff). The connector runs for ~1 hour retrying rate-limited requests and is killed by the Airbyte heartbeat timeout (3600s) before it ever emits a single message or thread.

**Evidence (HubSpot EMEA, c000389, Airbyte job 31389):**
- 104 rate-limit (429) hits on  between 23:12 and 00:13
- 21 channels emitted, **0 messages**, **0 threads**, 0 records committed
-  and  tables in integration DB are empty
- All 4 nightly syncs since March 23 have failed identically

Additionally,  and  each created a **new  instance** in their , causing up to 3× duplicate full-workspace fetches per sync.

## Fix

1. ****: Short-circuit pagination once all  names have been found — returns  immediately instead of fetching more pages. On a 21-channel filter this typically stops after 1–2 pages instead of 100+.

2. ** + **: Accept an optional  parameter. When provided, reuse the shared  instance instead of creating a fresh one, eliminating duplicate workspace scans.

3. ****: Pass the already-constructed  instance to both  and .

## Testing

- Unit test: connector with  should stop paginating after the page that contains , not continue to the end
- Integration test: a large workspace with many channels should complete channel discovery in seconds instead of minutes
- Docker image should be rebuilt and bumped from  to a new tag after merge
